### PR TITLE
Edit tournament name

### DIFF
--- a/components/tournaments/TournamentContainer/TournamentContainerClient.tsx
+++ b/components/tournaments/TournamentContainer/TournamentContainerClient.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { Database } from "@/database.types"
+import { Database } from "@/database.types";
 import TournamentRoundList from "../TournamentRoundList";
 import { User } from "@supabase/supabase-js";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { EditableTournamentArchetype } from "@/components/archetype/AddArchetype/AddTournamentArchetype";
 import { displayTournamentDate, getRecord } from "../utils/tournaments.utils";
 import AddTournamentRound from "../AddTournamentRound/AddTournamentRound";
+import { TournamentNameEdit } from "../TournamentNameEdit";
 
 interface TournamentContainerClientProps {
   tournament: Database['public']['Tables']['tournaments']['Row'];
@@ -17,24 +18,25 @@ interface TournamentContainerClientProps {
 export const TournamentContainerClient = (props: TournamentContainerClientProps) => {
   const [rounds, setRounds] = useState(props.rounds);
 
-  const updateClientRoundsOnAdd = useCallback((newRound: Database['public']['Tables']['tournament rounds']['Row']) => {
+  const updateClientRoundsOnAdd = (newRound: Database['public']['Tables']['tournament rounds']['Row']) => {
     setRounds([...rounds, newRound]);
-  }, [setRounds, rounds]);
+  };
 
-  const updateClientRoundsOnEdit = useCallback((newRound: Database['public']['Tables']['tournament rounds']['Row'], pos: number) => {
+  const updateClientRoundsOnEdit = (newRound: Database['public']['Tables']['tournament rounds']['Row'], pos: number) => {
     let newRounds = [...rounds];
     newRounds[pos] = newRound;
-    
     setRounds(newRounds);
-  }, [setRounds, rounds]);
+  };
 
   return (
     <div className="flex-1 flex flex-col w-full h-full px-8 py-4 sm:max-w-xl justify-between gap-2">
       <div className="flex flex-col gap-4">
         <div className="grid grid-cols-7 items-center">
           <div className="flex flex-col gap-1 col-span-5">
-            <h1 className="scroll-m-20 text-2xl font-bold tracking-tight">{props.tournament.name}</h1>
-            <h3 className="text-sm text-muted-foreground">{displayTournamentDate(props.tournament.date_from, props.tournament.date_to)}</h3>
+            <TournamentNameEdit tournament={props.tournament} />
+            <h3 className="text-sm text-muted-foreground">
+              {displayTournamentDate(props.tournament.date_from, props.tournament.date_to)}
+            </h3>
           </div>
           <EditableTournamentArchetype tournament={props.tournament} />
           <h2 className="text-xl font-semibold tracking-wider">{getRecord(props.rounds)}</h2>
@@ -42,7 +44,12 @@ export const TournamentContainerClient = (props: TournamentContainerClientProps)
         
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-4">
-            <TournamentRoundList tournament={props.tournament} userId={props.user?.id} rounds={rounds} updateClientRoundsOnEdit={updateClientRoundsOnEdit} />
+            <TournamentRoundList
+              tournament={props.tournament}
+              userId={props.user?.id}
+              rounds={rounds}
+              updateClientRoundsOnEdit={updateClientRoundsOnEdit}
+            />
             {props.user?.id && (props.user.id === props.tournament.user) && (
               <AddTournamentRound
                 tournamentId={props.tournament.id}
@@ -55,5 +62,5 @@ export const TournamentContainerClient = (props: TournamentContainerClientProps)
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/components/tournaments/TournamentNameEdit.tsx
+++ b/components/tournaments/TournamentNameEdit.tsx
@@ -33,7 +33,7 @@ export const TournamentNameEdit = ({ tournament }: TournamentNameEditProps) => {
         title: "Uh oh! Tournament name was not saved.",
         description: error.message,
       })
-    } else if (data) {
+    } else {
       toast({
         title: "Tournament name was saved correctly.",
       })
@@ -56,18 +56,16 @@ export const TournamentNameEdit = ({ tournament }: TournamentNameEditProps) => {
         </div>
       ) : (
         <div
-          className="relative"
+          className="flex items-center gap-2 relative"
           onMouseEnter={() => setHovering(true)}
           onMouseLeave={() => setHovering(false)}
         >
-          <h1
-            className="scroll-m-20 text-2xl font-bold tracking-tight"
-          >
+          <h1 className="scroll-m-20 text-2xl font-bold tracking-tight">
             {tournamentName ? tournamentName : "Loading..."}
           </h1>
           {hovering && (
             <PencilIcon
-              className="absolute right-0 top-0 cursor-pointer"
+              className="cursor-pointer"
               onClick={() => setIsEditing(true)}
             />
           )}

--- a/components/tournaments/TournamentNameEdit.tsx
+++ b/components/tournaments/TournamentNameEdit.tsx
@@ -1,0 +1,63 @@
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { createClient } from "@/utils/supabase/client";
+import { Database } from "@/database.types";
+import { toast } from "../ui/use-toast";
+
+interface TournamentNameEditProps {
+  tournament: Database['public']['Tables']['tournaments']['Row'];
+}
+
+export const TournamentNameEdit = ({ tournament }: TournamentNameEditProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [tournamentName, setTournamentName] = useState("");
+
+  useEffect(() => {
+    if (tournament?.name) {
+      setTournamentName(tournament.name);
+    } else {
+      console.error("Tournament name is missing or undefined.");
+    }
+  }, [tournament]);
+
+  const handleSave = async () => {
+    const supabase = createClient();
+    const { data, error } = await supabase.from('tournaments').update({ name: tournamentName }).eq('id', tournament.id);
+
+    if (error) {
+      toast({
+        variant: "destructive",
+        title: "Uh oh! Tournament name was not saved.",
+        description: error.message,
+      })
+    } else if (data) {
+      toast({
+        title: "Tournament name was saved correctly.",
+      })
+      setIsEditing(false);
+    }
+  };
+
+  return (
+    <div>
+      {isEditing ? (
+        <div className="flex gap-2 items-center">
+          <input
+            className="border rounded px-2 py-1"
+            value={tournamentName}
+            onChange={(e) => setTournamentName(e.target.value)}
+          />
+          <Button onClick={handleSave}>Save</Button>
+          <Button variant="outline" onClick={() => setIsEditing(false)}>Cancel</Button>
+        </div>
+      ) : (
+        <h1
+          className="scroll-m-20 text-2xl font-bold tracking-tight"
+          onDoubleClick={() => setIsEditing(true)}
+        >
+          {tournamentName ? tournamentName : "Loading..."}
+        </h1>
+      )}
+    </div>
+  );
+};

--- a/components/tournaments/TournamentNameEdit.tsx
+++ b/components/tournaments/TournamentNameEdit.tsx
@@ -60,7 +60,9 @@ export const TournamentNameEdit = ({ tournament }: TournamentNameEditProps) => {
           onMouseEnter={() => setHovering(true)}
           onMouseLeave={() => setHovering(false)}
         >
-          <h1 className="scroll-m-20 text-2xl font-bold tracking-tight">
+          <h1 className={`scroll-m-20 text-2xl font-bold tracking-tight transition-colors ${
+              hovering ? "text-gray-600" : "text-black"
+            }`}>
             {tournamentName ? tournamentName : "Loading..."}
           </h1>
           {hovering && (

--- a/components/tournaments/TournamentNameEdit.tsx
+++ b/components/tournaments/TournamentNameEdit.tsx
@@ -3,6 +3,8 @@ import { Button } from "@/components/ui/button";
 import { createClient } from "@/utils/supabase/client";
 import { Database } from "@/database.types";
 import { toast } from "../ui/use-toast";
+import { Input } from "../ui/input";
+import { PencilIcon } from "lucide-react";
 
 interface TournamentNameEditProps {
   tournament: Database['public']['Tables']['tournaments']['Row'];
@@ -11,6 +13,7 @@ interface TournamentNameEditProps {
 export const TournamentNameEdit = ({ tournament }: TournamentNameEditProps) => {
   const [isEditing, setIsEditing] = useState(false);
   const [tournamentName, setTournamentName] = useState("");
+  const [hovering, setHovering] = useState(false);
 
   useEffect(() => {
     if (tournament?.name) {
@@ -42,21 +45,33 @@ export const TournamentNameEdit = ({ tournament }: TournamentNameEditProps) => {
     <div>
       {isEditing ? (
         <div className="flex gap-2 items-center">
-          <input
+          <Input
             className="border rounded px-2 py-1"
             value={tournamentName}
             onChange={(e) => setTournamentName(e.target.value)}
+            autoFocus
           />
           <Button onClick={handleSave}>Save</Button>
           <Button variant="outline" onClick={() => setIsEditing(false)}>Cancel</Button>
         </div>
       ) : (
-        <h1
-          className="scroll-m-20 text-2xl font-bold tracking-tight"
-          onDoubleClick={() => setIsEditing(true)}
+        <div
+          className="relative"
+          onMouseEnter={() => setHovering(true)}
+          onMouseLeave={() => setHovering(false)}
         >
-          {tournamentName ? tournamentName : "Loading..."}
-        </h1>
+          <h1
+            className="scroll-m-20 text-2xl font-bold tracking-tight"
+          >
+            {tournamentName ? tournamentName : "Loading..."}
+          </h1>
+          {hovering && (
+            <PencilIcon
+              className="absolute right-0 top-0 cursor-pointer"
+              onClick={() => setIsEditing(true)}
+            />
+          )}
+        </div>
       )}
     </div>
   );

--- a/components/tournaments/TournamentNameEdit.tsx
+++ b/components/tournaments/TournamentNameEdit.tsx
@@ -4,7 +4,7 @@ import { createClient } from "@/utils/supabase/client";
 import { Database } from "@/database.types";
 import { toast } from "../ui/use-toast";
 import { Input } from "../ui/input";
-import { PencilIcon } from "lucide-react";
+import { CheckIcon, CheckSquareIcon, PencilIcon, XIcon } from "lucide-react";
 
 interface TournamentNameEditProps {
   tournament: Database['public']['Tables']['tournaments']['Row'];
@@ -51,8 +51,12 @@ export const TournamentNameEdit = ({ tournament }: TournamentNameEditProps) => {
             onChange={(e) => setTournamentName(e.target.value)}
             autoFocus
           />
-          <Button onClick={handleSave}>Save</Button>
-          <Button variant="outline" onClick={() => setIsEditing(false)}>Cancel</Button>
+          <Button onClick={handleSave}>
+            <CheckSquareIcon size={16}/>
+          </Button>
+          <Button variant="outline" onClick={() => setIsEditing(false)}>
+            <XIcon size={16}/>
+          </Button>
         </div>
       ) : (
         <div


### PR DESCRIPTION
PLEASE EDIT THIS.

Just getting a base out there for you to look at. Tournament name is the only editable field currently because I wasn't sure the vision in regards to if both name and date should be be edited with one button click.

Make changes as you see fit. No consideration of mobile.

- TournamentNameEdit component added
- Tournament name changes color on hover
- Edit icon appears on hover
- Toast message appears on success or error