### PR TITLE
feat: prefill most recent deck when adding a pocket match

### DIFF
--- a/components/pocket/AddPocketMatch.tsx
+++ b/components/pocket/AddPocketMatch.tsx
@@ -10,15 +10,31 @@ import { Label } from "../ui/label";
 import { createClient } from "@/utils/supabase/client";
 import { ToggleGroup, ToggleGroupItem } from "../ui/toggle-group";
 import { useToast } from "../ui/use-toast";
+import { usePocketGames } from "@/hooks/pocket/usePocketGames";
 import { T, useGT } from "gt-react";
 
 export const AddPocketMatch = ({ userId }: { userId: string}) => {
   const { toast } = useToast();
   const gt = useGT();
   const { mutate } = useSWRConfig();
+  const { data: pocketGames } = usePocketGames(userId);
+  const [open, setOpen] = useState(false);
   const [myDeck, setMyDeck] = useState<string | undefined>();
   const [opponentDeck, setOpponentDeck] = useState<string | undefined>();
   const [result, setResult] = useState<string | undefined>();
+
+  // Games come back newest-first, so the first entry is the deck the user
+  // most recently logged a match with.
+  const mostRecentDeck = pocketGames?.[0]?.deck ?? undefined;
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    // Prefill "My deck" with the most recently used deck so logging several
+    // matches with the same deck doesn't require re-selecting it each time.
+    if (nextOpen) {
+      setMyDeck((current) => current ?? mostRecentDeck);
+    }
+  }, [mostRecentDeck]);
 
   const handlePocketGameAdd = useCallback(async () => {
     const supabase = createClient();
@@ -47,7 +63,7 @@ export const AddPocketMatch = ({ userId }: { userId: string}) => {
   }, [userId, myDeck, opponentDeck, result]);
 
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger className="text-sm"><Button size='sm'><PlusIcon className="size-4 mr-1" /><T id="pocket.addMatch.button">Add match</T></Button></DialogTrigger>
       <DialogContent>
         <DialogHeader>


### PR DESCRIPTION
## What

When opening the **Add Pocket Match** dialog, the "My deck" dropdown is now pre-populated with the deck from your most recently logged match.

## Why

If you're logging several matches in a row with the same deck, you previously had to re-select your deck every single time. This prefills it so you can just set the opponent + result and hit Add.

## How

- `AddPocketMatch` now reads from `usePocketGames(userId)` (same SWR cache the list already uses — no extra fetch). Games come back newest-first, so `games[0].deck` is the most recently used deck.
- The dialog uses a controlled `open` state. On open, "My deck" is prefilled with the most recent deck **only when it's currently unset**, so it never clobbers an in-progress selection.
- The opponent deck and result are intentionally left blank since those vary per match.

After submitting, the newly added game becomes the most recent, so the next time you open the dialog it prefills with the deck you just used.

## Testing

- `tsc --noEmit`: no new errors from this change (only pre-existing tsconfig deprecation warnings + unrelated recoil-test type errors present on `main`).
- Full Jest suite passes (84/84).

Note: I couldn't exercise this in a live browser here (no auth/Supabase session in the sandbox), so verification is via typecheck, the test suite, and tracing the data flow.

https://claude.ai/code/session_014jyYRBnsTGQkc9RD4dfXqz

---
_Generated by [Claude Code](https://claude.ai/code/session_014jyYRBnsTGQkc9RD4dfXqz)_